### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -28,7 +28,7 @@ set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION} CACHE STRING "Python version used 
 find_package(Python ${PYTHON_VERSION} COMPONENTS Interpreter Development REQUIRED)
 # get_python_lib in python3 produces path which isn't in sys.path: https://bugs.launchpad.net/ubuntu/+source/python3-stdlib-extensions/+bug/1832215
 # execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
-set(PYTHON_SITE_PACKAGES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/dist-packages" CACHE STRING "Install location of the python package")  # This might be overridden below if built with catkin.
+set(PYTHON_SITE_PACKAGES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages" CACHE STRING "Install location of the python package")  # This might be overridden below if built with catkin.
 set(LIBRARY_NAME "PyKDL")
 
 # catkin-specific configuration (optional)


### PR DESCRIPTION
site-packages is used when building this package with ROS activated. Change `dist-packages` to `site-packages` for `PYTHON_SITE_PACKAGES_INSTALL_DIR`. `dist-packages` is not included in the sys.path by default. It is recommended to use site-packages instead.